### PR TITLE
chore(garmin): remove temporary 429-investigation sync diagnostics

### DIFF
--- a/src/lib/garmin/run-proxy-sync.ts
+++ b/src/lib/garmin/run-proxy-sync.ts
@@ -103,11 +103,6 @@ export async function runProxySync(args: RunProxySyncArgs): Promise<RunProxySync
         await wakeGarminService();
     }
 
-    // Temporary diagnostics for the prod 429 investigation: timestamped so repeated calls
-    // (e.g. an analytics-page mount loop) are visible in devtools.
-    const t0 = Date.now();
-    console.info('[garmin-sync] start', { mode, startDate, endDate, hasPassword: !!password });
-
     const proxy = await postJson(proxyUrl, {
         username: garminEmail,
         startDate,
@@ -115,17 +110,10 @@ export async function runProxySync(args: RunProxySyncArgs): Promise<RunProxySync
         ...(password ? { password } : {}),
     });
     if ('error' in proxy) {
-        console.warn('[garmin-sync] proxy unreachable', { error: proxy.error, ms: Date.now() - t0 });
         return { ok: false, code: 'PROXY_ERROR', message: proxy.error };
     }
     if (!proxy.ok) {
         const message = typeof proxy.payload.message === 'string' ? proxy.payload.message : undefined;
-        console.warn('[garmin-sync] proxy error', {
-            status: proxy.status,
-            code: proxy.payload.code,
-            message,
-            ms: Date.now() - t0,
-        });
         if (proxy.payload.code === 'INVALID_TOKEN' || isInvalidTokenMessage(message)) {
             return { ok: false, code: 'INVALID_TOKEN', message: message ?? 'Invalid Garmin token' };
         }
@@ -133,7 +121,6 @@ export async function runProxySync(args: RunProxySyncArgs): Promise<RunProxySync
     }
 
     const activities = Array.isArray(proxy.payload.data) ? proxy.payload.data : [];
-    console.info('[garmin-sync] proxy ok', { count: activities.length, ms: Date.now() - t0 });
 
     const persist = await postJson(`/api/user/${userId}/garmin/sync`, { activities, mode });
     if ('error' in persist) {


### PR DESCRIPTION
The prod 429 cause is resolved; drop the [garmin-sync] console diagnostics and timing in runProxySync. The browser-wake logic and the [garmin-wake] progress logs stay.