### PR TITLE
fix(seo): use per-page self-referencing canonical URL

### DIFF
--- a/src/lib/components/seo/Seo.svelte
+++ b/src/lib/components/seo/Seo.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { page } from '$app/stores';
     import { appConfig } from '@/constants/app.constants';
     import Screenshot from '$lib/images/gym-craft-app-ss.png';
 
@@ -28,5 +29,5 @@
     <meta name="twitter:description" content={metaDescription} />
     <meta name="twitter:image" content={ogImage} />
 
-    <link rel="canonical" href={baseUrl} />
+    <link rel="canonical" href={`${baseUrl}${$page.url.pathname}`} />
 </svelte:head>


### PR DESCRIPTION
The Seo component hardcoded the canonical link to the site root for every page, so /privacy-policy and /terms-of-use declared the homepage as their canonical. Build the canonical from the prod base URL plus the current pathname instead. Uses $page.url.pathname (not href) because prerendering emits a placeholder origin, and pathname also strips query strings and hashes.